### PR TITLE
Corrected converting occi:date into text

### DIFF
--- a/src/result.cc
+++ b/src/result.cc
@@ -223,7 +223,7 @@ char** node_db_oracle::Result::row(unsigned long* rowColumnLengths) throw(node_d
                         continue;
                     }
 
-                    string = date.toText("YYYY-MM-DD HH:II:SS");
+                    string = date.toText("YYYY-MM-DD HH24:MI:SS");
                 } else {
                     string = this->resultSet->getString(c + 1);
                 }


### PR DESCRIPTION
Hello,

The occi::date is not converted correct into text. The wrong part is time converting. This patch will correct this problem.

BTW, to convert the occi::date into text and after that to convert text into V8:Date it worst of performance.
I will check the possibility to convert direct into v8:Date.
