### PR TITLE
TNS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ new oracle.Database({
         console.log(rows.length + ' ROWS');
     });
 });
-```
+``
 
 ## LICENSE ##
 

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -1,10 +1,11 @@
 // Copyright 2011 Mariano Iglesias <mgiglesias@gmail.com>
 #include "./connection.h"
-
 node_db_oracle::Connection::Connection()
     : environment(NULL),
       connection(NULL) {
-    this->port = 1521;
+    this->port = 1521; 
+    this->tnsname = "";
+    this->sid = "";
     this->quoteName = '"';
     this->environment = oracle::occi::Environment::createEnvironment(oracle::occi::Environment::THREADED_MUTEXED);
     if (this->environment == NULL) {
@@ -27,7 +28,15 @@ void node_db_oracle::Connection::open() throw(node_db::Exception&) {
     this->close();
 
     std::ostringstream connection;
-    connection << "//" << this->hostname << ":" << this->port << "/" << this->database;
+    if( this->tnsname != ""){
+      TNSParser parser ( this->tnsname );
+      connection << parser.getConnectionString();
+    } else if( this->sid != "" ) {
+      connection << "(DESCRIPTION = (ADDRESS_LIST = (ADDRESS = (PROTOCOL = TCP)(HOST = " << this->hostname << ")(PORT = "<< this->port << ")))(CONNECT_DATA = (SID = " << this->sid << ")))"; 
+    } else {
+      connection << "//" << this->hostname << ":" << this->port << "/" << this->database;
+    }
+
     try {
         this->connection = this->environment->createConnection(this->user, this->password, connection.str());
         this->alive = true;
@@ -54,3 +63,22 @@ std::string node_db_oracle::Connection::version() const {
 node_db::Result* node_db_oracle::Connection::query(const std::string& query) const throw(node_db::Exception&) {
     return new node_db_oracle::Result(this->connection->createStatement(query));
 }
+
+
+std::string node_db_oracle::Connection::getSid() const {
+    return this->sid;
+}
+
+void node_db_oracle::Connection::setSid(const std::string& sid) {
+    this->sid = sid;
+}
+
+std::string node_db_oracle::Connection::getTNSName() const {
+    return this->tnsname;
+}
+
+void node_db_oracle::Connection::setTNSName(const std::string& tnsname) {
+    this->tnsname = tnsname;
+}
+
+

--- a/src/connection.h
+++ b/src/connection.h
@@ -7,6 +7,7 @@
 #include <sstream>
 #include "./node-db/connection.h"
 #include "./result.h"
+#include "./tns_parser.h"
 
 namespace node_db_oracle {
 class Connection : public node_db::Connection {
@@ -19,10 +20,20 @@ class Connection : public node_db::Connection {
         std::string escape(const std::string& string) const throw(node_db::Exception&);
         std::string version() const;
         node_db::Result* query(const std::string& query) const throw(node_db::Exception&);
+        
+        std::string getSid() const; 
+        void setSid(const std::string&);
+        std::string getTNSName() const;
+        void setTNSName(const std::string&);       
 
+        
+    protected:    
+        std::string sid;
+        std::string tnsname;
+         
     private:
         oracle::occi::Environment* environment;
-        oracle::occi::Connection* connection;
+        oracle::occi::Connection* connection;        
 };
 }
 

--- a/src/oracle.cc
+++ b/src/oracle.cc
@@ -53,6 +53,8 @@ v8::Handle<v8::Value> node_db_oracle::Oracle::set(const v8::Local<v8::Object> op
     ARG_CHECK_OBJECT_ATTR_OPTIONAL_STRING(options, hostname);
     ARG_CHECK_OBJECT_ATTR_OPTIONAL_STRING(options, user);
     ARG_CHECK_OBJECT_ATTR_OPTIONAL_STRING(options, password);
+    ARG_CHECK_OBJECT_ATTR_OPTIONAL_STRING(options, tnsname);
+    ARG_CHECK_OBJECT_ATTR_OPTIONAL_STRING(options, sid);
     ARG_CHECK_OBJECT_ATTR_OPTIONAL_STRING(options, database);
     ARG_CHECK_OBJECT_ATTR_OPTIONAL_UINT32(options, port);
 
@@ -62,6 +64,10 @@ v8::Handle<v8::Value> node_db_oracle::Oracle::set(const v8::Local<v8::Object> op
     v8::String::Utf8Value user(options->Get(user_key)->ToString());
     v8::String::Utf8Value password(options->Get(password_key)->ToString());
     v8::String::Utf8Value database(options->Get(database_key)->ToString());
+    
+    v8::String::Utf8Value sid(options->Get(sid_key)->ToString());
+    v8::String::Utf8Value tnsname(options->Get(tnsname_key)->ToString());
+
 
     if (options->Has(hostname_key)) {
         connection->setHostname(*hostname);
@@ -73,6 +79,14 @@ v8::Handle<v8::Value> node_db_oracle::Oracle::set(const v8::Local<v8::Object> op
 
     if (options->Has(password_key)) {
         connection->setPassword(*password);
+    }
+
+    if (options->Has(tnsname_key)) {
+        connection->setTNSName(*tnsname);
+    }
+    
+    if (options->Has(sid_key)) {
+        connection->setSid(*sid);
     }
 
     if (options->Has(database_key)) {

--- a/src/tns_parser.cc
+++ b/src/tns_parser.cc
@@ -1,0 +1,94 @@
+#include "./tns_parser.h"
+
+
+TNSParser::TNSParser(std::string tns_name){
+  this->tns_name = this->_toupper(tns_name);
+  this->connection_string = "";
+  this->_processTNS();
+};
+
+
+
+std::string TNSParser::getConnectionString(){
+  return this->connection_string;
+};
+
+
+std::string TNSParser::_toupper(std::string parser){
+   std::string return_val = "";
+   for(int i=0; i < parser.length(); i++){
+     return_val += toupper(parser.at(i));
+   }
+   return return_val;
+};
+
+void TNSParser::_processTNS(){
+  char *nTNS, *nOCL;
+  nTNS = getenv("TNS_ADMIN");
+  nOCL = getenv("ORACLE_HOME");
+  if(nTNS == NULL && nOCL == NULL){
+   // Through Variable Undefined Error
+  }else{
+    std::string tns_entry;
+    if( nTNS != NULL ){
+      tns_entry = this->_findEntry( strcat(nTNS, "tnsnames.ora" )  );
+    } 
+    if( nOCL != NULL && tns_entry.c_str() == NULL){ 
+      tns_entry = this->_findEntry( strcat(nOCL, "/network/admin/tnsnames.ora") );
+    }
+    if( tns_entry.c_str() != NULL){
+      this->connection_string = tns_entry;
+    }
+   }
+}
+
+std::string TNSParser::_findEntry(std::string file_path){
+   std::string line;
+   bool spool = false;
+   bool first = true;
+   std::string tns_entry;
+   int pos;
+   int count = 0;
+   std::fstream tns_file (file_path.c_str(), std::fstream::in);
+   if( tns_file.is_open() ){
+     while( tns_file.good() ){
+       getline(tns_file, line);
+       pos = 0;
+       if(!spool){
+         if((pos = this->_toupper(line).find( this->tns_name )) != std::string::npos){
+           pos = line.find('=', pos+1 ) + 1;
+           spool = true;
+         }
+       }
+       if( spool ){
+         while(true){
+           if( pos >= line.length() ){
+             break;
+           }else{
+             char letter = line.at(pos);
+             if(letter == '('){
+               count += 1;
+             }
+             if(letter == ')'){
+               count -= 1;
+               if(count == 0){ 
+                 tns_entry += letter;
+                 spool =false;
+                 break;
+               }
+             }
+             tns_entry += letter;
+           }
+           pos += 1;
+         }
+         
+        
+       }
+     }
+     tns_file.close();
+   }else{
+    // Through File Missing error
+   }
+   return tns_entry;
+
+} 

--- a/src/tns_parser.h
+++ b/src/tns_parser.h
@@ -1,0 +1,13 @@
+#include <fstream>
+#include <string>
+
+class TNSParser{
+  std::string connection_string, tns_name;
+  public:
+   TNSParser(std::string);
+   std::string getConnectionString();
+  private:
+   std::string _toupper(std::string);
+   void _processTNS();
+   std::string _findEntry(std::string);
+};

--- a/wscript
+++ b/wscript
@@ -45,7 +45,7 @@ def configure(conf):
 def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon")
   obj.target = "oracle_bindings"
-  obj.source = "lib/node-db/binding.cc lib/node-db/connection.cc lib/node-db/events.cc lib/node-db/exception.cc lib/node-db/query.cc lib/node-db/result.cc src/connection.cc src/oracle.cc src/query.cc src/result.cc src/oracle_bindings.cc"
+  obj.source = "lib/node-db/binding.cc lib/node-db/connection.cc lib/node-db/events.cc lib/node-db/exception.cc lib/node-db/query.cc lib/node-db/result.cc src/tns_parser.cc src/connection.cc src/oracle.cc src/query.cc src/result.cc src/oracle_bindings.cc"
   obj.includes = "lib/"
 
 def test(tst):


### PR DESCRIPTION
I added the following to the connection. 

If you supply tnsname and the tnsname if ORACLE_HOME or TNS_NAMES is specified and the tnsname.ora file contains the tnsname supplied it will use the TNS Connection string 

If you supply sid with the normal params it will format it as a TNS Connection string .

If it does not contain any tnsname or sid it will connect with your default connection. 
- Mike DiGioia
